### PR TITLE
fix: preserve PATHEXT for stdio mcp servers on windows

### DIFF
--- a/astrbot/core/agent/mcp_client.py
+++ b/astrbot/core/agent/mcp_client.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+import os
+import sys
 from contextlib import AsyncExitStack
 from datetime import timedelta
 from typing import Generic
@@ -43,6 +45,22 @@ def _prepare_config(config: dict) -> dict:
         config = config["mcpServers"][first_key]
     config.pop("active", None)
     return config
+
+
+def _prepare_stdio_env(config: dict) -> dict:
+    """Preserve Windows executable resolution for stdio subprocesses."""
+    if sys.platform != "win32":
+        return config
+
+    pathext = os.environ.get("PATHEXT")
+    if not pathext:
+        return config
+
+    prepared = config.copy()
+    env = dict(prepared.get("env") or {})
+    env.setdefault("PATHEXT", pathext)
+    prepared["env"] = env
+    return prepared
 
 
 async def _quick_test_mcp_connection(config: dict) -> tuple[bool, str]:
@@ -210,6 +228,7 @@ class MCPClient:
                 )
 
         else:
+            cfg = _prepare_stdio_env(cfg)
             server_params = mcp.StdioServerParameters(
                 **cfg,
             )

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -1,0 +1,64 @@
+import pytest
+
+from astrbot.core.agent import mcp_client
+
+
+def test_prepare_stdio_env_adds_pathext_on_windows(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(mcp_client.sys, "platform", "win32")
+    monkeypatch.setenv("PATHEXT", ".COM;.EXE")
+
+    cfg = {"command": "uvx", "args": ["mcp-server-fetch"]}
+
+    prepared = mcp_client._prepare_stdio_env(cfg)
+
+    assert prepared["env"]["PATHEXT"] == ".COM;.EXE"
+
+
+def test_prepare_stdio_env_merges_existing_env_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(mcp_client.sys, "platform", "win32")
+    monkeypatch.setenv("PATHEXT", ".COM;.EXE")
+
+    cfg = {
+        "command": "uvx",
+        "args": ["mcp-server-fetch"],
+        "env": {"HTTP_PROXY": "http://127.0.0.1:7890"},
+    }
+
+    prepared = mcp_client._prepare_stdio_env(cfg)
+
+    assert prepared["env"] == {
+        "HTTP_PROXY": "http://127.0.0.1:7890",
+        "PATHEXT": ".COM;.EXE",
+    }
+
+
+def test_prepare_stdio_env_preserves_user_defined_pathext(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(mcp_client.sys, "platform", "win32")
+    monkeypatch.setenv("PATHEXT", ".COM;.EXE")
+
+    cfg = {
+        "command": "uvx",
+        "args": ["mcp-server-fetch"],
+        "env": {"PATHEXT": ".BAT"},
+    }
+
+    prepared = mcp_client._prepare_stdio_env(cfg)
+
+    assert prepared["env"]["PATHEXT"] == ".BAT"
+
+
+def test_prepare_stdio_env_does_not_modify_non_windows(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(mcp_client.sys, "platform", "linux")
+    monkeypatch.setenv("PATHEXT", ".COM;.EXE")
+
+    cfg = {"command": "uvx", "args": ["mcp-server-fetch"]}
+
+    prepared = mcp_client._prepare_stdio_env(cfg)
+
+    assert "env" not in prepared


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
改动 astrbot/core/agent/mcp_client.py 当：
Windows 下启动 stdio MCP 服务时，如果用户没有显式传 env.PATHEXT，AstrBot 会从父进程补上 PATHEXT，避免 uvx --from git+... 无法解析 git.exe。用户自己配置的 PATHEXT 不会被覆盖。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<img width="1329" height="1377" alt="image" src="https://github.com/user-attachments/assets/c51bb5bb-a1e4-4120-843f-4d9904caedba" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## 由 Sourcery 提供的摘要

确保 Windows stdio MCP 子进程从父进程继承适当的可执行文件解析设置。

错误修复：
- 在 MCP 配置中未显式提供的情况下，为 Windows stdio MCP 服务器保留 `PATHEXT` 环境变量。

测试：
- 添加单元测试，覆盖 `PATHEXT` 注入、环境变量合并、用户自定义 `PATHEXT` 保留，以及在非 Windows 环境下的 stdio MCP 配置行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure Windows stdio MCP subprocesses inherit appropriate executable resolution settings from the parent process.

Bug Fixes:
- Preserve the PATHEXT environment variable for Windows stdio MCP servers when not explicitly provided in the MCP config.

Tests:
- Add unit tests covering PATHEXT injection, env merging, user-defined PATHEXT preservation, and non-Windows behavior for stdio MCP configuration.

</details>